### PR TITLE
removing hard coded api key from completions guide

### DIFF
--- a/pages/reference/completions.mdx
+++ b/pages/reference/completions.mdx
@@ -34,7 +34,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
     ```bash copy
     $ curl --location 'https://api.predictionguard.com/completions' \
     --header 'Content-Type: application/json' \
-    --header 'x-api-key: 3xbU4Q04lkydH7FIFQ9vWQEg0goIvi' \
+    --header 'x-api-key: <your access token>' \
     --data '{
         "model": "Nous-Hermes-Llama2-13B",
         "prompt": "The best joke I know is: "


### PR DESCRIPTION
We had a hard coded API key in a cURL request in the completions guide of the docs. This fixes that.