### PR TITLE
fixing request types and error in cURL requests

### DIFF
--- a/pages/reference/chat.mdx
+++ b/pages/reference/chat.mdx
@@ -51,7 +51,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
   </Tab>
   <Tab>
     ```bash copy
-    $ curl --location 'https://api.predictionguard.com/chat' \
+    $ curl --location --request POST 'https://api.predictionguard.com/chat' \
     --header 'Content-Type: application/json' \
     --header 'x-api-key: <your access token>' \
     --data '{
@@ -63,7 +63,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
             },
             {
                 "role": "user",
-                "content": "What'\''s up!"
+                "content": "What's up!"
             },
             {
                 "role": "assistant",

--- a/pages/reference/completions.mdx
+++ b/pages/reference/completions.mdx
@@ -32,7 +32,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
   </Tab>
   <Tab>
     ```bash copy
-    $ curl --location 'https://api.predictionguard.com/completions' \
+    $ curl --location --request POST 'https://api.predictionguard.com/completions' \
     --header 'Content-Type: application/json' \
     --header 'x-api-key: <your access token>' \
     --data '{


### PR DESCRIPTION
Adding `--request POST` to cURL requests for `completions` and `chat` references. Also fixes syntax error in `chat` cURL.