### PR TITLE
Switching version of llama 3 model

### DIFF
--- a/fern/docs/pages/models/details.mdx
+++ b/fern/docs/pages/models/details.mdx
@@ -20,7 +20,7 @@ Open access models are amazing these days! Each of these models was trained by a
 
 | Model Name                   | Type            | Use Case                                                | Prompt Format                      | Context Length | More Info                                                               |
 | ---------------------------- | --------------- | ------------------------------------------------------- | ---------------------------------- | -------------- | ----------------------------------------------------------------------- |
-| Meta-Llama-3-8B-Instruct     | Chat            | Instruction following or chat-like applications         | [Llama3](prompts#llama3)           | 4096           | [link](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)      |
+| Hermes-2-Pro-Llama-3-8B      | Chat            | Instruction following or chat-like applications         | [ChatML](prompts#chatml)           | 4096           | [link](https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B)      |
 | Nous-Hermes-Llama2-13B       | Text Generation | Generating output in response to arbitrary instructions | [Alpaca](prompts#alpaca)           | 4096           | [link](https://huggingface.co/NousResearch/Nous-Hermes-Llama2-13b)      |
 | Hermes-2-Pro-Mistral-7B      | Chat            | Instruction following or chat-like applications         | [ChatML](prompts#chatml)           | 4096           | [link](https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B)     |
 | Neural-Chat-7B               | Chat            | Instruction following or chat-like applications         | [Neural Chat](prompts#neural-chat) | 4096           | [link](https://huggingface.co/Intel/neural-chat-7b-v3-1)                |

--- a/fern/docs/pages/models/prompts.mdx
+++ b/fern/docs/pages/models/prompts.mdx
@@ -81,13 +81,3 @@ For prompts where context is injected:
 {context or user message}
 ### Response:
 ```
-
-## Llama3
-
-(Replace the portions of the prompt below in curly braces `{...}` with the appropriate information, and do not keep the curly braces)
-
-```
-<|begin_of_text|><|start_header_id|>system<|end_header_id|>
-{system prompt}<|eot_id|><|start_header_id|>user<|end_header_id|>
-{context or user message}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-```


### PR DESCRIPTION
Switching the Llama3 model in the docs to the Hermes Pro version, and removing the llama3 prompt template.