### PR TITLE
fix: updated link for prompt-engineering lab

### DIFF
--- a/fern/docs/pages/usingllms/prompt_engineering.mdx
+++ b/fern/docs/pages/usingllms/prompt_engineering.mdx
@@ -4,7 +4,7 @@ description: Prediction Guard in action
 ---
 
 (Run this example in Google Colab
-[here](https://drive.google.com/file/d/1ofThKWMoMVSdUGmDiRz4Ua1Zp7YV_b__/view?usp=sharing))
+[here](https://colab.research.google.com/drive/1ofThKWMoMVSdUGmDiRz4Ua1Zp7YV_b__))
 
 As we have seen in the previous examples, it is easy enough to prompt a generative
 AI model. Shoot off an API call, and suddently you have an answer, a machine


### PR DESCRIPTION
In the [lab](https://docs.predictionguard.com/guides-and-concepts/using-ll-ms/prompt-engineering),  the link to the google colab notebook is invalid. It redirects you to an image stored on google drive.

 I updated the value to redirect users to a google colab notebook.
<img width="1608" alt="Screenshot 2024-11-28 at 1 34 45 PM" src="https://github.com/user-attachments/assets/275da449-7938-4ca9-8016-c1cb5e4f7be6">
