### PR TITLE
Replace DeepSeek model with gpt-oss-120b

### DIFF
--- a/fern/docs/pages/options/llms.mdx
+++ b/fern/docs/pages/options/llms.mdx
@@ -12,7 +12,7 @@ These models are designed for text inference, and are used in the `/completions`
 | Model Name                   | Type                 | Use Case                                                        | Prompt Format                                          | Context Length | More Info                                           |
 | ---------------------------- | -------------------- | --------------------------------------------------------------- | -----------------------------------------------------  | -------------- | ----------------------------------------------------|
 | Hermes-3-Llama-3.1-70B       | Chat                 | Instruction following or chat-like applications                 | [ChatML](/options/prompts#chatml)                      | 20480             | [link](/options/llms#hermes-3-llama-31-70b)       |
-| DeepSeek-R1-Distill-Qwen-32B | Chat/Reasoning       | Instruction following or chat-like applications with reasoning  | [ChatML](/options/prompts#chatml)                      | 20480             | [link](/options/llms#deepseek-r1-distill-qwen-32b) |
+| gpt-oss-120b                  | Chat/Reasoning       | Instruction following or chat-like applications with reasoning  | [ChatML](/options/prompts#chatml)                      | 64000             | [link](/options/llms#gpt-oss-120b)                  |
 | Qwen2.5-Coder-14B-Instruct   | Code Generation      | Generating computer code or answering tech questions            | [ChatML](/options/prompts#chatml)                      | 20480             | [link](/options/llms#qwen25-coder-14b-instruct)   |
 | Hermes-3-Llama-3.1-8B        | Chat                 | Instruction following or chat-like applications                 | [ChatML](/options/prompts#chatml)                      | 32768             | [link](/options/llms#hermes-3-llama-31-8b)        |
 | neural-chat-7b-v3-3          | Chat                 | Instruction following or chat-like applications                 | [Neural Chat](/options/prompts#neural-chat)                 | 32768             | [link](/options/llms#neural-chat-7b-v3-3)               |
@@ -43,29 +43,23 @@ The Hermes 3 series builds and expands on the Hermes 2 set of capabilities,
 including more powerful and reliable function calling and structured output capabilities,
 generalist assistant capabilities, and improved code generation skills.
 
-### DeepSeek-R1-Distill-Qwen-32B
+### gpt-oss-120b
 
-DeepSeek-R1-Distill-Qwen-32B is a distilled reasoning model derived from DeepSeek-R1 achieving state-of-the-art 
-performance for dense models.
+gpt-oss-120b is OpenAI's open-weight model designed for powerful reasoning, agentic tasks, and versatile developer use cases. This model features configurable reasoning effort and full chain-of-thought capabilities.
 
 **Type:** Chat/Reasoning  
 **Use Case:** Instruction following or chat-like applications with reasoning  
 **Prompt Format:** [ChatML](/options/prompts#chatml)  
 
-https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
+https://huggingface.co/openai/gpt-oss-120b
 
-DeepSeek-R1 is a first-generation reasoning model developed through large-scale reinforcement learning (RL).  
-The process involved training DeepSeek-R1-Zero purely with RL, without supervised fine-tuning (SFT)  
-allowing it to develop emergent reasoning behaviors such as self-verification, reflection, and generating 
-long chain-of-thought (CoT) reasoning steps. To improve readability, coherence, and overall performance, 
-DeepSeek-R1 was further trained with cold-start data before RL. 
+gpt-oss-120b is part of OpenAI's gpt-oss series of open-weight models designed for powerful reasoning, agentic tasks, and versatile developer use cases. The model features:
 
-- DeepSeek-R1’s reasoning capabilities were distilled into smaller models, significantly improving  
-  their performance compared to models trained from scratch with RL.  
-- Several dense models were fine-tuned using DeepSeek-R1’s reasoning data, leading to state-of-the-art  
-  performance in benchmarks.  
-- Open-source checkpoints are available in multiple sizes: **1.5B, 7B, 8B, 14B, 32B, and 70B**,  
-  based on **Qwen2.5** and **Llama3** series.  
+- **Configurable reasoning effort:** Easily adjust the reasoning effort (low, medium, high) based on your specific use case and latency needs.
+- **Full chain-of-thought:** Gain complete access to the model's reasoning process, facilitating easier debugging and increased trust in outputs.
+- **Agentic capabilities:** Use the model's native capabilities for function calling, web browsing, Python code execution, and Structured Outputs.
+- **Apache 2.0 license:** Build freely without copyleft restrictions or patent risk—ideal for experimentation, customization, and commercial deployment.
+- **MXFP4 quantization:** The model was post-trained with MXFP4 quantization of the MoE weights, making it run efficiently on a single 80GB GPU (like NVIDIA H100 or AMD MI300X).  
 
 ### Qwen2.5-Coder-14B-Instruct
 

--- a/fern/docs/pages/options/prompts.mdx
+++ b/fern/docs/pages/options/prompts.mdx
@@ -79,14 +79,17 @@ appropriate information, and do not keep the curly braces)
 <|im_start|>assistant<|im_end|>
 ```
 
-## Deepseek
+## gpt-oss
+
+gpt-oss models use the ChatML format for optimal performance. The model is trained on the harmony response format and should be used with ChatML formatting.
 
 (Replace the portions of the prompt below in curly braces `{...}` with the
 appropriate information, and do not keep the curly braces)
 
 ```
-<|begin_of_sentence|>{prompt}
-### Instruction:
-{context or user message}
-### Response:
+<|im_start|>system
+{prompt}<|im_end|>
+<|im_start|>user
+{context or user message}<|im_end|>
+<|im_start|>assistant<|im_end|>
 ```

--- a/fern/docs/pages/usingllms/accessing_llms.mdx
+++ b/fern/docs/pages/usingllms/accessing_llms.mdx
@@ -22,7 +22,7 @@ etc. However, a common theme is the usage of LLMs through a REST API, which is e
 - Self-hosted using a DIY model serving API (Flask, FastAPI, etc.)
 
 We will use [Prediction Guard](/) to call open
-access LLMs (like Mistral, Llama3, Deepseek, etc.) via a standardized
+access LLMs (like Mistral, Llama3, gpt-oss, etc.) via a standardized
 OpenAI-like API. This will allow us to explore the full range of LLMs available.
 Further, it will illustrate how companies can access a wide range of models
 (outside of the GPT family).

--- a/fern/docs/pages/usingllms/chaining_retrieval.mdx
+++ b/fern/docs/pages/usingllms/chaining_retrieval.mdx
@@ -222,7 +222,7 @@ def response_chain(message, convo_context, info_context):
 
   # Determine what kind of message this is.
   result = client.completions.create(
-      model="deepseek-coder-6.7b-instruct",
+      model="gpt-oss-120b",
       prompt=category_prompt.format(query=message)
   )
 
@@ -247,7 +247,7 @@ def response_chain(message, convo_context, info_context):
 
     # Handle the code generation request.
     result = client.completions.create(
-        model="deepseek-coder-6.7b-instruct",
+        model="gpt-oss-120b",
         prompt=code_prompt.format(query=message),
         max_completion_tokens=500
     )

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "Prediction-Guard",
-  "version": "0.64.24"
+  "version": "0.81.0"
 }


### PR DESCRIPTION
- Updated model table entry from DeepSeek-R1-Distill-Qwen-32B to gpt-oss-120b
- Changed context window from 20,480 to 64,000 tokens
- Updated model description with GPT-OSS-120B capabilities and features
- Replaced DeepSeek prompt format with ChatML format for gpt-oss models
- Updated code examples to use gpt-oss-120b model
- Standardized all model name references to lowercase format